### PR TITLE
Add non-owning set_mock method to Contract

### DIFF
--- a/boot-core/src/contract.rs
+++ b/boot-core/src/contract.rs
@@ -42,7 +42,7 @@ where
     ExecT: Clone + fmt::Debug + PartialEq + JsonSchema + DeserializeOwned + 'static,
     QueryT: CustomQuery + DeserializeOwned + 'static,
 {
-    /// CHecks the environment for the wasm dir configuration and returns the path to the wasm file
+    /// Checks the environment for the wasm dir configuration and returns the path to the wasm file
     pub fn get_wasm_code_path(&self) -> Result<String, BootError> {
         let wasm_code_path = self
             .wasm_code_path
@@ -52,7 +52,11 @@ where
         let wasm_code_path = if wasm_code_path.contains(".wasm") {
             wasm_code_path.to_string()
         } else {
-            format!("{}/{}.wasm", env::var("ARTIFACTS_DIR").unwrap(), wasm_code_path)
+            format!(
+                "{}/{}.wasm",
+                env::var("ARTIFACTS_DIR").unwrap(),
+                wasm_code_path
+            )
         };
 
         Ok(wasm_code_path)
@@ -107,6 +111,10 @@ impl<Chain: BootEnvironment + Clone> Contract<Chain> {
     pub fn with_mock(mut self, mock_contract: Box<dyn TestContract<Empty, Empty>>) -> Self {
         self.source.contract_endpoints = Some(mock_contract);
         self
+    }
+
+    pub fn set_mock(&mut self, mock_contract: Box<dyn TestContract<Empty, Empty>>) {
+        self.source.contract_endpoints = Some(mock_contract);
     }
 
     /// Sets the address of the contract in the local state

--- a/boot-core/src/keys/public.rs
+++ b/boot-core/src/keys/public.rs
@@ -545,7 +545,7 @@ mod tst {
             "terravalconspub1zcjduepqpxp3kxmn8yty9eh8a0e6tasdna04q7zsl88u7dyup7fv7t06pl9q342a8t";
         let pk = PublicKey::from_tendermint_key(cons_pub_str)?;
         assert_eq!(cons_str, pk.tendermint(PREFIX)?);
-        assert_eq!(hex_str, hex::encode_upper(&pk.raw_address.unwrap()));
+        assert_eq!(hex_str, hex::encode_upper(pk.raw_address.unwrap()));
 
         let pk2 = PublicKey::from_tendermint_address(hex_str)?;
         assert_eq!(cons_str, &pk2.tendermint(PREFIX)?);

--- a/boot-core/src/networks/mod.rs
+++ b/boot-core/src/networks/mod.rs
@@ -1,5 +1,5 @@
 mod juno;
 mod osmosis;
+pub use super::daemon::state::{ChainInfo, NetworkInfo, NetworkKind};
 pub use juno::{JUNO_1, LOCAL_JUNO, UNI_5};
 pub use osmosis::{LOCAL_OSMO, OSMO_4};
-pub use super::daemon::state::{ChainInfo,NetworkInfo,NetworkKind};

--- a/packages/boot-fns-derive/src/execute_fns.rs
+++ b/packages/boot-fns-derive/src/execute_fns.rs
@@ -43,7 +43,7 @@ pub fn execute_fns_derive(ast: DeriveInput) -> TokenStream {
 
                 let (maybe_coins_attr, passed_coins) = if is_payable {
                     (quote!(coins: &[::cosmwasm_std::Coin]),quote!(Some(coins)))
-                }else { 
+                } else {
                     (quote!(),quote!(None))
                 };
                 let variant_attr = variant_idents.iter();

--- a/packages/boot-fns-derive/src/query_fns.rs
+++ b/packages/boot-fns-derive/src/query_fns.rs
@@ -50,7 +50,6 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                             self.query(&msg)
                         }
                     )
-                    
                 }
             }
         }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:white_small_square: Bugfix
:white_small_square: New feature
:black_small_square: Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
This change adds a `set_mock` method to the `Contract` which  differs from the builder method `with_mock` in that it doesn't take ownership.

The other changes are formatting-related


## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->


## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:white_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
