### PR TITLE
Support nested boot functions

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -13,6 +13,8 @@ jobs:
   lint:
     name: Clippy Linter
     runs-on: self-hosted
+    container:
+        image: rust:latest
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2
@@ -37,6 +39,8 @@ jobs:
   compile:
     name: Compile
     runs-on: self-hosted
+    container:
+        image: rust:latest
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2

--- a/boot-core/src/lib.rs
+++ b/boot-core/src/lib.rs
@@ -14,7 +14,7 @@ mod tx_handler;
 
 // pub mod traits;
 pub use boot_contract_derive::boot_contract;
-pub use boot_fns_derive::{ExecuteFns,QueryFns};
+pub use boot_fns_derive::{ExecuteFns, QueryFns};
 pub use contract::Contract;
 pub use daemon::{
     core::Daemon,

--- a/packages/boot-fns-derive/Cargo.toml
+++ b/packages/boot-fns-derive/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1"
+proc-macro2 = "1"
 syn = { version = "1", features = ["full", "extra-traits"] }
 convert_case = "0.6.0"
 cosmwasm-schema-derive = "1.1"

--- a/packages/boot-fns-derive/src/execute_fns.rs
+++ b/packages/boot-fns-derive/src/execute_fns.rs
@@ -2,7 +2,9 @@ extern crate proc_macro;
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, Ident};
+use syn::{visit_mut::VisitMut, DeriveInput, Fields, Ident};
+
+use crate::helpers::{impl_into, LexiographicMatching};
 
 fn payable(v: &syn::Variant) -> bool {
     for attr in &v.attrs {
@@ -15,6 +17,17 @@ fn payable(v: &syn::Variant) -> bool {
 
 pub fn execute_fns_derive(ast: DeriveInput) -> TokenStream {
     let name = &ast.ident;
+
+    // Does the struct have an #[impl_into] attribute?
+    let impl_into = impl_into(&ast);
+
+    // If so, we need to add a .into() to the execute fn and set the entrypoint message message
+    let (maybe_into, entrypoint_msg_type) = if let Some(entrypoint_msg_type) = impl_into {
+        (quote!(.into()), quote!(#entrypoint_msg_type))
+    } else {
+        (quote!(), quote!(#name))
+    };
+
     let bname = Ident::new(&format!("{}Fns", name), name.span());
 
     let syn::Data::Enum(syn::DataEnum {
@@ -25,20 +38,25 @@ pub fn execute_fns_derive(ast: DeriveInput) -> TokenStream {
         unimplemented!();
     };
 
-    let variant_fns = variants.iter().filter_map( |variant|{
+    let variant_fns = variants.into_iter().filter_map( |mut variant|{
         let variant_name = variant.ident.clone();
-        let is_payable = payable(variant);
-        match &variant.fields {
+        let is_payable = payable(&variant);
+        match &mut variant.fields {
             Fields::Unnamed(_) => None,
             Fields::Unit => None,
             Fields::Named(variant_fields) => {
+                // sort fields on field name
+                LexiographicMatching::default().visit_fields_named_mut(variant_fields);
 
                 // parse these fields as arguments to function
                 let mut variant_func_name =
                 format_ident!("{}", variant_name.to_string().to_case(Case::Snake));
                 variant_func_name.set_span(variant_name.span());
 
-                let variant_idents = variant_fields.named.clone();
+                let mut variant_idents = variant_fields.named.clone();
+                // remove any attributes for use in fn arguments
+                variant_idents.iter_mut().for_each(|f| f.attrs = vec![]);
+
                 let variant_ident_content_names = variant_idents.iter().map(|f|f.ident.clone().unwrap());
 
                 let (maybe_coins_attr, passed_coins) = if is_payable {
@@ -53,7 +71,7 @@ pub fn execute_fns_derive(ast: DeriveInput) -> TokenStream {
                         let msg = #name::#variant_name {
                             #(#variant_ident_content_names,)*
                         };
-                        self.execute(&msg,#passed_coins)
+                        self.execute(&msg #maybe_into,#passed_coins)
                     }
                 ))
             }
@@ -61,7 +79,7 @@ pub fn execute_fns_derive(ast: DeriveInput) -> TokenStream {
     });
 
     let derived_trait = quote!(
-        pub trait #bname<Chain: ::boot_core::BootEnvironment>: ::boot_core::prelude::BootExecute<Chain, ExecuteMsg = #name> {
+        pub trait #bname<Chain: ::boot_core::BootEnvironment>: ::boot_core::prelude::BootExecute<Chain, ExecuteMsg = #entrypoint_msg_type> {
             #(#variant_fns)*
         }
     );
@@ -70,7 +88,7 @@ pub fn execute_fns_derive(ast: DeriveInput) -> TokenStream {
         #[automatically_derived]
         impl<T, Chain: ::boot_core::BootEnvironment> #bname<Chain> for T
         where
-            T: ::boot_core::prelude::BootExecute<Chain, ExecuteMsg = #name>{}
+            T: ::boot_core::prelude::BootExecute<Chain, ExecuteMsg = #entrypoint_msg_type>{}
     );
 
     let expand = quote!(

--- a/packages/boot-fns-derive/src/helpers.rs
+++ b/packages/boot-fns-derive/src/helpers.rs
@@ -1,0 +1,75 @@
+use std::cmp::Ordering;
+
+use syn::{punctuated::Punctuated, token::Comma, DeriveInput, Field, FieldsNamed, Type};
+
+pub(crate) fn impl_into(ast: &DeriveInput) -> Option<Type> {
+    for attr in &ast.attrs {
+        if attr.path.segments.len() == 1 && attr.path.segments[0].ident == "impl_into" {
+            return Some(
+                attr.parse_args().unwrap_or_else(|_| {
+                    panic!("impl_into must be followed by the entrypoint type")
+                }),
+            );
+        }
+    }
+    None
+}
+
+#[derive(Default)]
+pub(crate) struct LexiographicMatching {}
+
+impl syn::visit_mut::VisitMut for LexiographicMatching {
+    fn visit_fields_named_mut(&mut self, i: &mut FieldsNamed) {
+        let mut fields: Vec<Field> = i.named.iter().map(Clone::clone).collect();
+        // sort fields on field name and optionality
+        fields.sort_by(|a, b| {
+            maybe_compare_option(a, b, "Option").unwrap_or_else(|| {
+                a.ident
+                    .as_ref()
+                    .unwrap()
+                    .to_string()
+                    .cmp(&b.ident.as_ref().unwrap().to_string())
+            })
+        });
+        let sorted_fields: Punctuated<Field, Comma> = Punctuated::from_iter(fields);
+        *i = FieldsNamed {
+            named: sorted_fields,
+            ..i.clone()
+        };
+    }
+}
+
+fn maybe_compare_option(a: &Field, b: &Field, wrapper: &str) -> Option<Ordering> {
+    if is_option(wrapper, &a.ty) && is_option(wrapper, &b.ty) {
+        return Some(
+            a.ident
+                .as_ref()
+                .unwrap()
+                .to_string()
+                .cmp(&b.ident.as_ref().unwrap().to_string()),
+        );
+    }
+    // if one is an option, the other one is lesser
+    else if is_option(wrapper, &a.ty) {
+        return Some(Ordering::Greater);
+    } else if is_option(wrapper, &b.ty) {
+        return Some(Ordering::Less);
+    }
+    None
+}
+
+fn is_option(wrapper: &str, ty: &'_ syn::Type) -> bool {
+    if let syn::Type::Path(ref p) = ty {
+        if p.path.segments.len() != 1 || p.path.segments[0].ident != wrapper {
+            return false;
+        }
+
+        if let syn::PathArguments::AngleBracketed(ref inner_ty) = p.path.segments[0].arguments {
+            if inner_ty.args.len() != 1 {
+                return false;
+            }
+            return true;
+        }
+    }
+    false
+}

--- a/packages/boot-fns-derive/src/helpers.rs
+++ b/packages/boot-fns-derive/src/helpers.rs
@@ -35,8 +35,6 @@ pub(crate) fn process_impl_into(
             let type_args = e.path.segments[0].arguments.clone();
             if let PathArguments::AngleBracketed(argo) = type_args {
                 type_generics = argo.args
-            } else {
-                panic!("impl_into must have exactly one type argument");
             }
         };
         (quote!(.into()), quote!(#entrypoint_msg_type), type_generics)

--- a/packages/boot-fns-derive/src/lib.rs
+++ b/packages/boot-fns-derive/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "128"]
 
 mod execute_fns;
+mod helpers;
 mod query_fns;
 
 extern crate proc_macro;
@@ -9,13 +10,13 @@ use proc_macro::TokenStream;
 
 use syn::{parse_macro_input, DeriveInput, ItemEnum};
 
-#[proc_macro_derive(ExecuteFns, attributes(payable))]
+#[proc_macro_derive(ExecuteFns, attributes(payable, impl_into))]
 pub fn boot_execute(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     execute_fns::execute_fns_derive(ast)
 }
 
-#[proc_macro_derive(QueryFns, attributes(returns))]
+#[proc_macro_derive(QueryFns, attributes(returns, impl_into))]
 pub fn boot_query(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as ItemEnum);
     query_fns::query_fns_derive(ast)

--- a/packages/boot-fns-derive/src/query_fns.rs
+++ b/packages/boot-fns-derive/src/query_fns.rs
@@ -67,7 +67,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
     );
 
     let derived_trait_impl = quote!(
-        impl<SupportedContract, Chain: ::boot_core::BootEnvironment> #bname<Chain, #type_generics> for SupportedContract
+        impl<SupportedContract, Chain: ::boot_core::BootEnvironment, #type_generics> #bname<Chain, #type_generics> for SupportedContract
         where
             SupportedContract: ::boot_core::prelude::BootQuery<Chain, QueryMsg = #entrypoint_msg_type>{}
     );


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:black_small_square: Bugfix
:black_small_square: New feature
:white_small_square: Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Some endpoint messages might contain generic arguments. These types of messages were not supported until now. To fix this without assuming anything about the messages users aim to nest in their entrypoint messages we resorted to adding a `#[impl_into(X)]` attribute that can be used alongside the `ExecuteFns` and `QueryFns` macros. 

### Usage
Lets take this execute message:
```rust
#[cosmwasm_schema::cw_serde]
pub enum WrapperExecuteMsg<BaseMsg> {
    /// A configuration message.
    Base(BaseMsg),
}
```
If we would want to generate functions for each variant of `BaseMsg` we would be required to introspect the `BaseMsg` struct, which is impossible since it's a generic.

Instead if we expect the `BaseMsg` to implement `Into<ExecuteMsg<BaseMsg>>` (which is not a hard ask) then we can parse the message into it's required type. 

Hence the macro takes the expected contract entrypoint message. 
 ```rust
// Define the endpoint message's type. Can contain other generics.
let type EndpointExecuteMsg = WrapperExecuteMsg<BaseExecuteMsg>;

#[cosmwasm_schema::cw_serde]
#[derive(boot_core::ExecuteFns)]
// Tell ExecuteFns that the contract expects an EndpointExecuteMsg and that BaseExecuteMsg implements .into()
#[impl_into(EndpointExecuteMsg)]
pub enum BaseExecuteMsg {
    /// Updates the base config
    UpdateConfig { ans_host_address: Option<String> },
}
 ```

Now any BOOT struct that has the `#[boot_contract(_ ,ExecuteMsg, ...)]` attribute will have a `.update_config()` method! 

- Bug fixes: 
Without deterministic function arguments a change to a message struct's field positions would resolve in a breaking change on the function. 
Example:  

```
enum Foo {
    TBar {
       bar: u8,
       foo_bar: String
    }
}
// Generates 
x.t_bar(bar,foo_bar)

// While 
enum Foo {
    TBar {
       foo_bar: String
       bar: u8,
    }
}
// Generates 
x.t_bar(foo_bar, bar)
```
This is fixed by sorting the struct arguments before generating the fn. 

A fix for #39 is also included. 

closes #39 

## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->


## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:white_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
