### PR TITLE
implement `CallAs` for Mock and Daemon environments.

### DIFF
--- a/boot-core/src/daemon/core.rs
+++ b/boot-core/src/daemon/core.rs
@@ -256,9 +256,8 @@ impl TxHandler for Daemon {
 impl<T: BootExecute<Daemon> + ContractInstance<Daemon> + Clone> CallAs<Daemon> for T {
     type Sender = Wallet;
 
-    fn set_sender(&mut self, sender: &Self::Sender) -> &mut Self {
+    fn set_sender(&mut self, sender: &Self::Sender) {
         self.as_instance_mut().chain.sender = sender.clone();
-        self
     }
 
     fn call_as(&self, sender: &Self::Sender) -> Self {

--- a/boot-core/src/daemon/core.rs
+++ b/boot-core/src/daemon/core.rs
@@ -6,7 +6,10 @@ use super::{
     state::{DaemonOptions, DaemonState, NetworkKind},
     tx_resp::CosmTxResponse,
 };
-use crate::{contract::ContractCodeReference, state::ChainState, tx_handler::TxHandler};
+use crate::{
+    contract::ContractCodeReference, state::ChainState, tx_handler::TxHandler, BootExecute, CallAs,
+    ContractInstance,
+};
 use cosmrs::{
     cosmwasm::{MsgExecuteContract, MsgInstantiateContract, MsgMigrateContract},
     tendermint::Time,
@@ -247,6 +250,21 @@ impl TxHandler for Daemon {
             time,
             chain_id: block.header.chain_id.to_string(),
         })
+    }
+}
+
+impl<T: BootExecute<Daemon> + ContractInstance<Daemon> + Clone> CallAs<Daemon> for T {
+    type Sender = Wallet;
+
+    fn set_sender(&mut self, sender: &Self::Sender) -> &mut Self {
+        self.as_instance_mut().chain.sender = sender.clone();
+        self
+    }
+
+    fn call_as(&self, sender: &Self::Sender) -> Self {
+        let mut contract = self.clone();
+        contract.set_sender(sender);
+        contract
     }
 }
 

--- a/boot-core/src/interface.rs
+++ b/boot-core/src/interface.rs
@@ -152,7 +152,7 @@ pub trait CallAs<Chain: CwEnv>: BootExecute<Chain> + ContractInstance<Chain> + C
     type Sender: Clone;
 
     /// Set the sender for the contract
-    fn set_sender(&mut self, sender: &Self::Sender) -> &mut Self;
+    fn set_sender(&mut self, sender: &Self::Sender);
 
     /// Call a contract as a different sender.  
     /// Creates a new copy of the contract with a different sender

--- a/boot-core/src/mock/core.rs
+++ b/boot-core/src/mock/core.rs
@@ -252,9 +252,8 @@ impl<S: StateInterface> TxHandler for Mock<S> {
 impl<T: BootExecute<Mock> + ContractInstance<Mock> + Clone> CallAs<Mock> for T {
     type Sender = Addr;
 
-    fn set_sender(&mut self, sender: &Addr) -> &mut Self {
+    fn set_sender(&mut self, sender: &Addr) {
         self.as_instance_mut().chain.sender = sender.clone();
-        self
     }
 
     fn call_as(&self, sender: &Self::Sender) -> Self {

--- a/boot-core/src/mock/core.rs
+++ b/boot-core/src/mock/core.rs
@@ -3,7 +3,7 @@ use crate::{
     contract::ContractCodeReference,
     state::{ChainState, StateInterface},
     tx_handler::TxHandler,
-    BootError, Contract,
+    BootError, BootExecute, CallAs, ContractInstance,
 };
 use cosmwasm_std::{Addr, Empty, Event, Uint128};
 use cw_multi_test::{next_block, App, AppResponse, BasicApp, Executor};
@@ -249,9 +249,17 @@ impl<S: StateInterface> TxHandler for Mock<S> {
     }
 }
 
-impl Contract<Mock> {
-    pub fn set_sender(&mut self, sender: Addr) -> &mut Self {
-        self.chain.sender = sender;
+impl<T: BootExecute<Mock> + ContractInstance<Mock> + Clone> CallAs<Mock> for T {
+    type Sender = Addr;
+
+    fn set_sender(&mut self, sender: &Addr) -> &mut Self {
+        self.as_instance_mut().chain.sender = sender.clone();
         self
+    }
+
+    fn call_as(&self, sender: &Self::Sender) -> Self {
+        let mut contract = self.clone();
+        contract.set_sender(sender);
+        contract
     }
 }

--- a/boot-cw-plus/src/cw1.rs
+++ b/boot-cw-plus/src/cw1.rs
@@ -1,4 +1,4 @@
-use boot_core::{contract, CwEnv, Contract};
+use boot_core::{contract, Contract, CwEnv};
 use cosmwasm_std::Empty;
 use cw1_whitelist::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use cw_multi_test::ContractWrapper;


### PR DESCRIPTION
as the title says, this allows us to use `.call_as()` in generic contexts!