### PR TITLE
Prefix Result with core::result::

### DIFF
--- a/packages/boot-fns-derive/src/query_fns.rs
+++ b/packages/boot-fns-derive/src/query_fns.rs
@@ -47,7 +47,7 @@ pub fn query_fns_derive(input: ItemEnum) -> TokenStream {
                 let variant_attr = variant_fields.iter();
                 quote!(
                         #[allow(clippy::too_many_arguments)]
-                        fn #variant_func_name(&self, #(#variant_attr,)*) -> Result<#response, ::boot_core::BootError> {
+                        fn #variant_func_name(&self, #(#variant_attr,)*) -> ::core::result::Result<#response, ::boot_core::BootError> {
                             let msg = #name::#variant_name {
                                 #(#variant_idents,)*
                             };


### PR DESCRIPTION
This change prefixes the `Result` used in the `query_fns_derive` with `::core::result::` because of alternative results that may be imported like `std::fmt::Result`
